### PR TITLE
Fix HttpPromise callbacks signatures

### DIFF
--- a/static/javascripts/accounts/controllers/account-settings.controller.js
+++ b/static/javascripts/accounts/controllers/account-settings.controller.js
@@ -53,15 +53,15 @@
        * @name accountSuccessFn
        * @desc Update `account` for view
        */
-      function accountSuccessFn(data, status, headers, config) {
-        vm.account = data.data;
+      function accountSuccessFn(response) {
+        vm.account = response.data;
       }
 
       /**
        * @name accountErrorFn
        * @desc Redirect to index
        */
-      function accountErrorFn(data, status, headers, config) {
+      function accountErrorFn(response) {
         $location.url('/');
         Snackbar.error('That user does not exist.');
       }
@@ -80,7 +80,7 @@
        * @name accountSuccessFn
        * @desc Redirect to index and display success snackbar
        */
-      function accountSuccessFn(data, status, headers, config) {
+      function accountSuccessFn(response) {
         Authentication.unauthenticate();
         window.location = '/';
 
@@ -92,8 +92,8 @@
        * @name accountErrorFn
        * @desc Display error snackbar
        */
-      function accountErrorFn(data, status, headers, config) {
-        Snackbar.error(data.error);
+      function accountErrorFn(response) {
+        Snackbar.error(response.data.detail);
       }
     }
 
@@ -112,7 +112,7 @@
        * @name accountSuccessFn
        * @desc Show success snackbar
        */
-      function accountSuccessFn(data, status, headers, config) {
+      function accountSuccessFn(response) {
         Snackbar.show('Your account has been updated.');
       }
 
@@ -121,8 +121,8 @@
        * @name accountErrorFn
        * @desc Show error snackbar
        */
-      function accountErrorFn(data, status, headers, config) {
-        Snackbar.error(data.error);
+      function accountErrorFn(response) {
+        Snackbar.error(response.data.detail);
       }
     }
   }

--- a/static/javascripts/accounts/controllers/account.controller.js
+++ b/static/javascripts/accounts/controllers/account.controller.js
@@ -37,8 +37,8 @@
       * @name accountSuccessAccount
       * @desc Update `account` on viewmodel
       */
-      function accountSuccessFn(data, status, headers, config) {
-        vm.account = data.data;
+      function accountSuccessFn(response) {
+        vm.account = response.data;
       }
 
 
@@ -46,7 +46,7 @@
       * @name accountErrorFn
       * @desc Redirect to index and show error Snackbar
       */
-      function accountErrorFn(data, status, headers, config) {
+      function accountErrorFn(response) {
         $location.url('/');
         Snackbar.error('That user does not exist.');
       }
@@ -56,8 +56,8 @@
         * @name postsSucessFn
         * @desc Update `posts` on viewmodel
         */
-      function postsSuccessFn(data, status, headers, config) {
-        vm.posts = data.data;
+      function postsSuccessFn(response) {
+        vm.posts = response.data;
       }
 
 
@@ -65,8 +65,8 @@
         * @name postsErrorFn
         * @desc Show error snackbar
         */
-      function postsErrorFn(data, status, headers, config) {
-        Snackbar.error(data.data.error);
+      function postsErrorFn(response) {
+        Snackbar.error(response.data.detail);
       }
     }
   }

--- a/static/javascripts/authentication/services/authentication.service.js
+++ b/static/javascripts/authentication/services/authentication.service.js
@@ -77,8 +77,8 @@
        * @name loginSuccessFn
        * @desc Set the authenticated account and redirect to index
        */
-      function loginSuccessFn(data, status, headers, config) {
-        Authentication.setAuthenticatedAccount(data.data);
+      function loginSuccessFn(response) {
+        Authentication.setAuthenticatedAccount(response.data);
 
         window.location = '/';
       }
@@ -87,7 +87,7 @@
        * @name loginErrorFn
        * @desc Log "Epic failure!" to the console
        */
-      function loginErrorFn(data, status, headers, config) {
+      function loginErrorFn(response) {
         console.error('Epic failure!');
       }
     }
@@ -107,7 +107,7 @@
        * @name logoutSuccessFn
        * @desc Unauthenticate and redirect to index with page reload
        */
-      function logoutSuccessFn(data, status, headers, config) {
+      function logoutSuccessFn(response) {
         Authentication.unauthenticate();
 
         window.location = '/';
@@ -117,7 +117,7 @@
        * @name logoutErrorFn
        * @desc Log "Epic failure!" to the console
        */
-      function logoutErrorFn(data, status, headers, config) {
+      function logoutErrorFn(response) {
         console.error('Epic failure!');
       }
     }
@@ -143,7 +143,7 @@
       * @name registerSuccessFn
       * @desc Log the new user in
       */
-      function registerSuccessFn(data, status, headers, config) {
+      function registerSuccessFn(response) {
         Authentication.login(email, password);
       }
 
@@ -151,7 +151,7 @@
       * @name registerErrorFn
       * @desc Log "Epic failure!" to the console
       */
-      function registerErrorFn(data, status, headers, config) {
+      function registerErrorFn(response) {
         console.error('Epic failure!');
       }
     }

--- a/static/javascripts/layout/controllers/index.controller.js
+++ b/static/javascripts/layout/controllers/index.controller.js
@@ -43,8 +43,8 @@
        * @name postsSuccessFn
        * @desc Update thoughts array on view
        */
-      function postsSuccessFn(data, status, headers, config) {
-        vm.posts = data.data;
+      function postsSuccessFn(response) {
+        vm.posts = response.data;
       }
 
 
@@ -52,8 +52,8 @@
        * @name postsErrorFn
        * @desc Show snackbar with error
        */
-      function postsErrorFn(data, status, headers, config) {
-        Snackbar.error(data.error);
+      function postsErrorFn(response) {
+        Snackbar.error(response.data.detail);
       }
     }
   }

--- a/static/javascripts/posts/controllers/new-post.controller.js
+++ b/static/javascripts/posts/controllers/new-post.controller.js
@@ -41,7 +41,7 @@
        * @name createPostSuccessFn
        * @desc Show snackbar with success message
        */
-      function createPostSuccessFn(data, status, headers, config) {
+      function createPostSuccessFn(response) {
         Snackbar.show('Success! Post created.');
       }
 
@@ -50,9 +50,9 @@
        * @name createPostErrorFn
        * @desc Propogate error event and show snackbar with error message
        */
-      function createPostErrorFn(data, status, headers, config) {
+      function createPostErrorFn(response) {
         $rootScope.$broadcast('post.created.error');
-        Snackbar.error(data.error);
+        Snackbar.error(response.data.detail);
       }
     }
   }


### PR DESCRIPTION
From the [Angular docs](https://docs.angularjs.org/api/ng/service/$http):

> Returns a promise object with the standard then method and two http specific methods: success and error. The then method takes two arguments a success and an error callback which will be called with a response object. The success and error methods take a single argument - a function that will be called when the request succeeds or fails respectively. The arguments passed into these functions are destructured representation of the response object passed into the then method.

In other words, the correct signatures are:

``` javascript
$http.get('/api/users/').success(function (data, status, headers, config) {
    console.log(data);
}).error(function (data, status, headers, config) {
    console.log(":-(");
});
```

or

``` javascript
$http.get('/api/users/').then(function (response) {
    console.log(response.data);
}, function (response) {
    console.log(":-(");
});
```

Cheers and many thanks for your awesome tutorial!
Ștefan
